### PR TITLE
fix: proper name for getHistoricalRates function

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -5,11 +5,11 @@ There are three basic output formats: `array`, `json` and `csv`
 ### [basic-array.js](https://github.com/Leo4815162342/dukascopy-node/blob/master/examples/basic/basic-array.js)
 
 ```javascript
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2021-02-01'),
@@ -49,11 +49,11 @@ Full example output: [basic-array.output.json](https://github.com/Leo4815162342/
 ### [basic-json.js](https://github.com/Leo4815162342/dukascopy-node/blob/master/examples/basic/basic-json.js)
 
 ```javascript
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2021-02-01'),
@@ -99,11 +99,11 @@ Full example output: [basic-json.output.json](https://github.com/Leo4815162342/d
 ### [basic-csv.js](https://github.com/Leo4815162342/dukascopy-node/blob/master/examples/basic/basic-csv.js)
 
 ```javascript
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2021-02-01'),

--- a/examples/basic/basic-array.js
+++ b/examples/basic/basic-array.js
@@ -1,8 +1,8 @@
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2021-02-01'),

--- a/examples/basic/basic-csv.js
+++ b/examples/basic/basic-csv.js
@@ -1,8 +1,8 @@
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2021-02-01'),

--- a/examples/basic/basic-json.js
+++ b/examples/basic/basic-json.js
@@ -1,8 +1,8 @@
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2021-02-01'),

--- a/examples/with-cache/README.md
+++ b/examples/with-cache/README.md
@@ -11,11 +11,11 @@ All the binary artifacts (which are downloaded from the dukascopy servers) will 
 ### Example: [with-cache.js](https://github.com/Leo4815162342/dukascopy-node/blob/master/examples/with-cache/with-cache.js)
 
 ```javascript
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2021-02-01'),
@@ -44,11 +44,11 @@ If you run the same code again, then you will notice that it's faster, since the
 ### Example: [with-cache-custom-folder.js](https://github.com/Leo4815162342/dukascopy-node/blob/master/examples/with-cache/with-cache-custom-folder.js)
 
 ```javascript
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2021-02-01'),

--- a/examples/with-cache/with-cache-custom-folder.js
+++ b/examples/with-cache/with-cache-custom-folder.js
@@ -1,8 +1,8 @@
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2021-02-01'),

--- a/examples/with-cache/with-cache.js
+++ b/examples/with-cache/with-cache.js
@@ -1,8 +1,8 @@
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2021-02-01'),

--- a/examples/with-custom-batching/README.md
+++ b/examples/with-custom-batching/README.md
@@ -7,11 +7,11 @@ In some cases such list of URLs can be huge. Since we do not want to overwhelm D
 For example - fetching historical price data for `eurusd` for the whole month of June in 2019, with minutely aggregation (`m1` timeframe):
 
 ```javascript
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2019-06-01'),
@@ -80,11 +80,11 @@ If you want to change those values, to let's say `batchSize: 15` and `pauseBetwe
 ### Example: [with-custom-batching.js](https://github.com/Leo4815162342/dukascopy-node/blob/master/examples/with-custom-batching/with-custom-batching.js)
 
 ```javascript
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2019-06-01'),

--- a/examples/with-custom-batching/with-custom-batching.js
+++ b/examples/with-custom-batching/with-custom-batching.js
@@ -1,8 +1,8 @@
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2019-06-01'),

--- a/examples/with-tick-data/README.md
+++ b/examples/with-tick-data/README.md
@@ -7,11 +7,11 @@ Since `tick` timeframe represents a raw price change, the output will NOT contai
 ### Example: [with-tick-data.js](https://github.com/Leo4815162342/dukascopy-node/blob/master/examples/with-tick-data/with-tick-data.js)
 
 ```javascript
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2021-03-30'),

--- a/examples/with-tick-data/with-tick-data.js
+++ b/examples/with-tick-data/with-tick-data.js
@@ -1,8 +1,8 @@
-const { getHistoricRates } = require('dukascopy-node');
+const { getHistoricalRates } = require('dukascopy-node');
 
 (async () => {
   try {
-    const data = await getHistoricRates({
+    const data = await getHistoricalRates({
       instrument: 'eurusd',
       dates: {
         from: new Date('2021-03-30'),

--- a/examples/with-typescript/README.md
+++ b/examples/with-typescript/README.md
@@ -4,7 +4,7 @@
 
 ```typescript
 
-import { getHistoricRates, Config, Instrument, Timeframe, Format } from 'dukascopy-node';
+import { getHistoricalRates, Config, Instrument, Timeframe, Format } from 'dukascopy-node';
 
 const config: Config = {
   instrument: Instrument.eurusd,
@@ -17,7 +17,7 @@ const config: Config = {
   priceType: Price.bid
 };
 
-getHistoricRates(config).then(data => console.log(data));
+getHistoricalRates(config).then(data => console.log(data));
 
 ```
 
@@ -31,7 +31,7 @@ When `json` is requested as format for non-tick timeframe
 
 ```typescript
 
-import { getHistoricRates, Config, Instrument, Timeframe, Format } from 'dukascopy-node';
+import { getHistoricalRates, Config, Instrument, Timeframe, Format } from 'dukascopy-node';
 
 const config: Config = {
   instrument: Instrument.eurusd,
@@ -44,7 +44,7 @@ const config: Config = {
   priceType: Price.bid
 };
 
-getHistoricRates(config).then(data => console.log(data));
+getHistoricalRates(config).then(data => console.log(data));
 ```
 
 ![JsonItem](https://github.com/Leo4815162342/dukascopy-node/blob/master/examples/with-typescript/json_item.png?raw=true)
@@ -57,7 +57,7 @@ When `array` is requested as format for non-tick timeframe
 
 ```typescript
 
-import { getHistoricRates, Config, Instrument, Timeframe, Format } from 'dukascopy-node';
+import { getHistoricalRates, Config, Instrument, Timeframe, Format } from 'dukascopy-node';
 
 const config: Config = {
   instrument: Instrument.eurusd,
@@ -70,7 +70,7 @@ const config: Config = {
   priceType: Price.bid
 };
 
-getHistoricRates(config).then(data => console.log(data));
+getHistoricalRates(config).then(data => console.log(data));
 ```
 
 ![ArrayItem](https://github.com/Leo4815162342/dukascopy-node/blob/master/examples/with-typescript/array_item.png?raw=true)
@@ -83,7 +83,7 @@ When `json` is requested as format for tick timeframe
 
 ```typescript
 
-import { getHistoricRates, Config, Instrument, Timeframe, Format } from 'dukascopy-node';
+import { getHistoricalRates, Config, Instrument, Timeframe, Format } from 'dukascopy-node';
 
 const config: Config = {
   instrument: Instrument.eurusd,
@@ -96,7 +96,7 @@ const config: Config = {
   priceType: Price.bid
 };
 
-getHistoricRates(config).then(data => console.log(data));
+getHistoricalRates(config).then(data => console.log(data));
 ```
 
 ![JsonItemTick](https://github.com/Leo4815162342/dukascopy-node/blob/master/examples/with-typescript/json_item_tick.png?raw=true)
@@ -109,7 +109,7 @@ When `array` is requested as format for tick timeframe
 
 ```typescript
 
-import { getHistoricRates, Config, Instrument, Timeframe, Format } from 'dukascopy-node';
+import { getHistoricalRates, Config, Instrument, Timeframe, Format } from 'dukascopy-node';
 
 const config: Config = {
   instrument: Instrument.eurusd,
@@ -122,7 +122,7 @@ const config: Config = {
   priceType: Price.bid
 };
 
-getHistoricRates(config).then(data => console.log(data));
+getHistoricalRates(config).then(data => console.log(data));
 ```
 
 ![ArrayTickItem](https://github.com/Leo4815162342/dukascopy-node/blob/master/examples/with-typescript/array_tick_item.png?raw=true)
@@ -135,7 +135,7 @@ When `csv` is requested as format
 
 ```typescript
 
-import { getHistoricRates, Config, Instrument, Timeframe, Format } from 'dukascopy-node';
+import { getHistoricalRates, Config, Instrument, Timeframe, Format } from 'dukascopy-node';
 
 const config: Config = {
   instrument: Instrument.eurusd,
@@ -148,7 +148,7 @@ const config: Config = {
   priceType: Price.bid
 };
 
-getHistoricRates(config).then(data => console.log(data));
+getHistoricalRates(config).then(data => console.log(data));
 ```
 
 ![string](https://github.com/Leo4815162342/dukascopy-node/blob/master/examples/with-typescript/string.png?raw=true)

--- a/src/getHistoricalRates.ts
+++ b/src/getHistoricalRates.ts
@@ -132,4 +132,10 @@ export async function getHistoricalRates(config: Config): Promise<Output> {
   return formattedData;
 }
 
+/**
+ * @deprecated use `getHistoricalRates` instead
+ *
+ * Preserving for backwards compatibility
+ * @see https://github.com/Leo4815162342/dukascopy-node/pull/73
+ */
 export const getHistoricRates = getHistoricalRates;

--- a/src/getHistoricalRates.ts
+++ b/src/getHistoricalRates.ts
@@ -25,14 +25,14 @@ import debug from 'debug';
 
 const DEBUG_NAMESPACE = 'dukascopy-node';
 
-export async function getHistoricRates(config: ConfigArrayItem): Promise<ArrayItem[]>;
-export async function getHistoricRates(config: ConfigArrayTickItem): Promise<ArrayTickItem[]>;
-export async function getHistoricRates(config: ConfigJsonItem): Promise<JsonItem[]>;
-export async function getHistoricRates(config: ConfigJsonTickItem): Promise<JsonItemTick[]>;
-export async function getHistoricRates(config: ConfigCsvItem): Promise<string>;
-export async function getHistoricRates(config: Config): Promise<Output>;
+export async function getHistoricalRates(config: ConfigArrayItem): Promise<ArrayItem[]>;
+export async function getHistoricalRates(config: ConfigArrayTickItem): Promise<ArrayTickItem[]>;
+export async function getHistoricalRates(config: ConfigJsonItem): Promise<JsonItem[]>;
+export async function getHistoricalRates(config: ConfigJsonTickItem): Promise<JsonItemTick[]>;
+export async function getHistoricalRates(config: ConfigCsvItem): Promise<string>;
+export async function getHistoricalRates(config: Config): Promise<Output>;
 
-export async function getHistoricRates(config: Config): Promise<Output> {
+export async function getHistoricalRates(config: Config): Promise<Output> {
   debug(`${DEBUG_NAMESPACE}:version`)(`${version} (node ${process.version})`);
 
   const { input, isValid, validationErrors } = validateConfigNode(config);
@@ -131,3 +131,5 @@ export async function getHistoricRates(config: Config): Promise<Output> {
 
   return formattedData;
 }
+
+export const getHistoricRates = getHistoricalRates;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,4 +23,4 @@ export { ArrayItem, ArrayTickItem, JsonItem, JsonItemTick, Output } from './outp
 
 export { RuleDate, RuleBoolean, RuleNumber, RuleString, RuleObject } from 'fastest-validator';
 
-export { getHistoricRates } from './getHistoricRates';
+export { getHistoricRates, getHistoricalRates } from './getHistoricRates';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,4 +23,4 @@ export { ArrayItem, ArrayTickItem, JsonItem, JsonItemTick, Output } from './outp
 
 export { RuleDate, RuleBoolean, RuleNumber, RuleString, RuleObject } from 'fastest-validator';
 
-export { getHistoricRates, getHistoricalRates } from './getHistoricRates';
+export { getHistoricRates, getHistoricalRates } from './getHistoricalRates';


### PR DESCRIPTION
Renaming main function `getHistoricRates` to a grammatically correct version - `getHistoricalRates`

more info: https://www.grammarly.com/blog/historic-historical/