### PR TITLE
Update chalk to version 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,77 +1,77 @@
 {
-	"name": "dukascopy-node",
-	"version": "1.19.1",
-	"description": "Node.js library for downloading historical market tick data for 800+ different instruments (stocks, crypto, commodities, forex, etc.)",
-	"main": "dist/index.js",
-	"module": "dist/esm/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"bin": {
-		"dukascopy-cli": "./dist/cli/index.js"
-	},
-	"scripts": {
-		"build": "rm -rf dist && tsup-node src/index.ts src/cli/index.ts --format esm,cjs --dts --legacy-output",
-		"test": "vitest run",
-		"coverage": "vitest run --coverage",
-		"format": "prettier --config .prettierrc 'src/**/*.ts' --write",
-		"lint": "eslint ./src --ext ts --ext js",
-		"gen:meta": "ts-node src/utils/instrument-meta-data/generate-data.ts",
-		"gen:instruments-md": "ts-node src/utils/instrument-meta-data/generate-instrument-md.ts",
-		"release": "standard-version && git push --follow-tags origin master && pnpm build && npm publish"
-	},
-	"author": "leonid.pyrlia",
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/Leo4815162342/dukascopy-node"
-	},
-	"keywords": [
-		"dukascopy",
-		"stock-data",
-		"forex-data",
-		"historical-data",
-		"ohlc",
-		"tick-data",
-		"exchange-rates",
-		"commodities",
-		"cfd",
-		"crypto",
-		"ethusd",
-		"btcusd"
-	],
-	"dependencies": {
-		"chalk": "3.0.0",
-		"cli-progress": "3.10.0",
-		"commander": "5.0.0",
-		"debug": "4.3.4",
-		"fastest-validator": "1.10.0",
-		"fs-extra": "10.1.0",
-		"lzma-purejs": "0.9.3",
-		"node-fetch": "2.6.7",
-		"python-struct": "1.1.3"
-	},
-	"devDependencies": {
-		"@types/cli-progress": "3.9.2",
-		"@types/debug": "4.1.7",
-		"@types/fs-extra": "9.0.13",
-		"@types/node": "17.0.25",
-		"@types/node-fetch": "2.6.1",
-		"@typescript-eslint/eslint-plugin": "5.20.0",
-		"@typescript-eslint/parser": "5.20.0",
-		"eslint": "8.13.0",
-		"eslint-config-prettier": "8.5.0",
-		"eslint-plugin-prettier": "4.0.0",
-		"prettier": "2.6.2",
-		"standard-version": "9.3.2",
-		"ts-node": "9.1.1",
-		"tsup": "5.12.5",
-		"typescript": "4.6.3",
-		"utility-types": "3.10.0",
-		"vitest": "0.9.3"
-	},
-	"engines": {
-		"node": ">=12"
-	}
+ "name": "dukascopy-node",
+ "version": "1.19.1",
+ "description": "Node.js library for downloading historical market tick data for 800+ different instruments (stocks, crypto, commodities, forex, etc.)",
+ "main": "dist/index.js",
+ "module": "dist/esm/index.js",
+ "types": "dist/index.d.ts",
+ "files": [
+  "dist"
+ ],
+ "bin": {
+  "dukascopy-cli": "./dist/cli/index.js"
+ },
+ "scripts": {
+  "build": "rm -rf dist && tsup-node src/index.ts src/cli/index.ts --format esm,cjs --dts --legacy-output",
+  "test": "vitest run",
+  "coverage": "vitest run --coverage",
+  "format": "prettier --config .prettierrc 'src/**/*.ts' --write",
+  "lint": "eslint ./src --ext ts --ext js",
+  "gen:meta": "ts-node src/utils/instrument-meta-data/generate-data.ts",
+  "gen:instruments-md": "ts-node src/utils/instrument-meta-data/generate-instrument-md.ts",
+  "release": "standard-version && git push --follow-tags origin master && pnpm build && npm publish"
+ },
+ "author": "leonid.pyrlia",
+ "license": "MIT",
+ "repository": {
+  "type": "git",
+  "url": "https://github.com/Leo4815162342/dukascopy-node"
+ },
+ "keywords": [
+  "dukascopy",
+  "stock-data",
+  "forex-data",
+  "historical-data",
+  "ohlc",
+  "tick-data",
+  "exchange-rates",
+  "commodities",
+  "cfd",
+  "crypto",
+  "ethusd",
+  "btcusd"
+ ],
+ "dependencies": {
+  "chalk": "^4.0.0",
+  "cli-progress": "3.10.0",
+  "commander": "5.0.0",
+  "debug": "4.3.4",
+  "fastest-validator": "1.10.0",
+  "fs-extra": "10.1.0",
+  "lzma-purejs": "0.9.3",
+  "node-fetch": "2.6.7",
+  "python-struct": "1.1.3"
+ },
+ "devDependencies": {
+  "@types/cli-progress": "3.9.2",
+  "@types/debug": "4.1.7",
+  "@types/fs-extra": "9.0.13",
+  "@types/node": "17.0.25",
+  "@types/node-fetch": "2.6.1",
+  "@typescript-eslint/eslint-plugin": "5.20.0",
+  "@typescript-eslint/parser": "5.20.0",
+  "eslint": "8.13.0",
+  "eslint-config-prettier": "8.5.0",
+  "eslint-plugin-prettier": "4.0.0",
+  "prettier": "2.6.2",
+  "standard-version": "9.3.2",
+  "ts-node": "9.1.1",
+  "tsup": "5.12.5",
+  "typescript": "4.6.3",
+  "utility-types": "3.10.0",
+  "vitest": "0.9.3"
+ },
+ "engines": {
+  "node": ">=12"
+ }
 }


### PR DESCRIPTION
This pull request was created using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It bumps chalk to version 4.0.0.

<strong>Sign up your project [here](https://jsfix.live/scanner) to receive notifications about other packages updates JSFIX can help with.</strong>

***<h3> Pull request details</h3>

<details open><summary><strong> 🚧 - Manual review items (please check before merge)</strong></summary><blockquote class="pr-blockquote"><details>
<summary>Breaking changes not automatically fixable by JSFIX.</summary><blockquote class="pr-blockquote">

<details open>
<summary>General breaking changes (not related to specific API usages in your code).</summary>

* Require Node.js 10
</details>

</blockquote></details>

</blockquote></details><details><summary>Additional details</summary><blockquote class="pr-blockquote"><details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* Change the Level TypeScript type to be a union instead of enum
</details>

</blockquote></details>

***

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.