### PR TITLE
Support "now" in and "to" cli parameter.

### DIFF
--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -13,7 +13,7 @@ program
   .option('-d, --debug', 'Output extra debugging', false)
   .option('-s, --silent', 'Hides the search config in the CLI output', false)
   .requiredOption('-i, --instrument <value>', 'Trading instrument')
-  .requiredOption('-from, --date-from <value>', `From date (yyyy-mm-dd or '${now}')`)
+  .requiredOption('-from, --date-from <value>', `From date (yyyy-mm-dd')`)
   .requiredOption('-to, --date-to <value>', `To date (yyyy-mm-dd or '${now}')`)
   .option(
     '-t, --timeframe <value>',
@@ -37,12 +37,8 @@ program.parse(process.argv);
 
 const options = program.opts();
 
-// Parse "now" date parameters and convert
-// them to current time.
-if (options.dateFrom === now) {
-  options.dateFrom = new Date();
-}
-
+// Parse "now" date parameter and convert
+// it to current time.
 if (options.dateTo === now) {
   options.dateTo = new Date();
 }

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -7,12 +7,14 @@ import { Format } from '../config/format';
 import { Price } from '../config/price-types';
 import { Timeframe } from '../config/timeframes';
 
+const now = 'now';
+
 program
   .option('-d, --debug', 'Output extra debugging', false)
   .option('-s, --silent', 'Hides the search config in the CLI output', false)
   .requiredOption('-i, --instrument <value>', 'Trading instrument')
-  .requiredOption('-from, --date-from <value>', 'From date (yyyy-mm-dd)')
-  .requiredOption('-to, --date-to <value>', 'To date (yyyy-mm-dd)')
+  .requiredOption('-from, --date-from <value>', `From date (yyyy-mm-dd or '${now}')`)
+  .requiredOption('-to, --date-to <value>', `To date (yyyy-mm-dd or '${now}')`)
   .option(
     '-t, --timeframe <value>',
     'Timeframe aggregation (tick, m1, m5, m15, m30, h1, h4, d1, mn1)',
@@ -37,7 +39,6 @@ const options = program.opts();
 
 // Parse "now" date parameters and convert
 // them to current time.
-const now = 'now';
 if (options.dateFrom === now) {
   options.dateFrom = new Date();
 }

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -14,7 +14,7 @@ program
   .option('-s, --silent', 'Hides the search config in the CLI output', false)
   .requiredOption('-i, --instrument <value>', 'Trading instrument')
   .requiredOption('-from, --date-from <value>', 'From date (yyyy-mm-dd)')
-  .requiredOption('-to, --date-to <value>', `To date (yyyy-mm-dd or '${now}')`)
+  .option('-to, --date-to <value>', `To date (yyyy-mm-dd or '${now}')`, now)
   .option(
     '-t, --timeframe <value>',
     'Timeframe aggregation (tick, m1, m5, m15, m30, h1, h4, d1, mn1)',

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -13,7 +13,7 @@ program
   .option('-d, --debug', 'Output extra debugging', false)
   .option('-s, --silent', 'Hides the search config in the CLI output', false)
   .requiredOption('-i, --instrument <value>', 'Trading instrument')
-  .requiredOption('-from, --date-from <value>', `From date (yyyy-mm-dd')`)
+  .requiredOption('-from, --date-from <value>', 'From date (yyyy-mm-dd)')
   .requiredOption('-to, --date-to <value>', `To date (yyyy-mm-dd or '${now}')`)
   .option(
     '-t, --timeframe <value>',

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -35,6 +35,16 @@ program.parse(process.argv);
 
 const options = program.opts();
 
+// Parse "now" date parameters and convert
+// them to current time.
+if (options.dateFrom === 'now') {
+  options.dateFrom = new Date();
+}
+
+if (options.dateTo === 'now') {
+  options.dateTo = new Date();
+}
+
 export interface CliConfig extends Config {
   dir: string;
   silent: boolean;

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -37,11 +37,12 @@ const options = program.opts();
 
 // Parse "now" date parameters and convert
 // them to current time.
-if (options.dateFrom === 'now') {
+const now = 'now';
+if (options.dateFrom === now) {
   options.dateFrom = new Date();
 }
 
-if (options.dateTo === 'now') {
+if (options.dateTo === now) {
   options.dateTo = new Date();
 }
 


### PR DESCRIPTION
This is a proposed fix for the feature request in https://github.com/Leo4815162342/dukascopy-node/issues/76

It accepts "now" as input for the "to" parameter.