### PR TITLE
feat(cli): inline output

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Options:
   -chpath, --cache-path <value>  Folder path for cache data (default: "./.dukascopy-cache")
   -r, --retries <value>          Number of retries for a failed artifact download (default: 0)
   -rp, --retry-pause <value>     Pause between retries in milliseconds (default: 500)
+  -in, --inline                  Makes files smaller in size by removing new lines in the output (default: false)
   -h, --help                     display help for command
 ```
 </details>

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Options:
   -chpath, --cache-path <value>  Folder path for cache data (default: "./.dukascopy-cache")
   -r, --retries <value>          Number of retries for a failed artifact download (default: 0)
   -rp, --retry-pause <value>     Pause between retries in milliseconds (default: 500)
-  -in, --inline                  Makes files smaller in size by removing new lines in the output (default: false)
+  -in, --inline                  Makes files smaller in size by removing new lines in the output (works only with json and array formats) (default: false)
   -h, --help                     display help for command
 ```
 </details>

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -34,7 +34,7 @@ program
   .option('-rp, --retry-pause <value>', 'Pause between retries in milliseconds', Number, 500)
   .option(
     '-in, --inline',
-    'Makes files smaller in size by removing new lines in the output',
+    'Makes files smaller in size by removing new lines in the output (works only with json and array formats)',
     false
   );
 

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -31,7 +31,12 @@ program
   .option('-ch, --cache', 'Use cache', false)
   .option('-chpath, --cache-path <value>', 'Folder path for cache data', './.dukascopy-cache')
   .option('-r, --retries <value>', 'Number of retries for a failed artifact download', Number, 0)
-  .option('-rp, --retry-pause <value>', 'Pause between retries in milliseconds', Number, 500);
+  .option('-rp, --retry-pause <value>', 'Pause between retries in milliseconds', Number, 500)
+  .option(
+    '-in, --inline',
+    'Makes files smaller in size by removing new lines in the output',
+    false
+  );
 
 program.parse(process.argv);
 
@@ -47,6 +52,7 @@ export interface CliConfig extends Config {
   dir: string;
   silent: boolean;
   debug: boolean;
+  inline: boolean;
 }
 
 const cliConfig: CliConfig = {
@@ -69,7 +75,8 @@ const cliConfig: CliConfig = {
   cacheFolderPath: options.cachePath,
   retryCount: options.retries,
   pauseBetweenRetriesMs: options.retryPause,
-  debug: options.debug
+  debug: options.debug,
+  inline: options.inline
 };
 
 const cliSchema: InputSchema<CliConfig> = {
@@ -77,7 +84,8 @@ const cliSchema: InputSchema<CliConfig> = {
   ...{
     dir: { type: 'string', required: true } as RuleString,
     silent: { type: 'boolean', required: false } as RuleBoolean,
-    debug: { type: 'boolean', required: false } as RuleBoolean
+    debug: { type: 'boolean', required: false } as RuleBoolean,
+    inline: { type: 'boolean', required: false } as RuleBoolean
   }
 };
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,7 +38,8 @@ let {
   cacheFolderPath,
   dir,
   silent,
-  debug: isDebugActive
+  debug: isDebugActive,
+  inline
 } = input;
 
 if (isDebugActive) {
@@ -137,7 +138,8 @@ if (isDebugActive) {
 
         const formatted = formatOutput({ processedData: filteredData, timeframe, format });
 
-        savePayload = format === 'csv' ? formatted : JSON.stringify(formatted, null, 2);
+        savePayload =
+          format === 'csv' ? formatted : JSON.stringify(formatted, null, inline ? undefined : 2);
       } else {
         savePayload = format === 'csv' ? '' : JSON.stringify([]);
       }


### PR DESCRIPTION
| No inline| With inline|
|-|-|
|`npx dukascopy-node -i btcusd -from 2019-01-01 -to 2019-01-14 -t m1 -f json`|`npx dukascopy-node -i btcusd -from 2019-01-01 -to 2019-01-14 -t m1 -f json --inline`|
|<img width="525" alt="Screenshot 2022-08-24 at 20 09 15" src="https://user-images.githubusercontent.com/12486774/186492208-5e263585-5bb8-47c6-b159-e92f63e96da0.png">|<img width="526" alt="Screenshot 2022-08-24 at 20 09 33" src="https://user-images.githubusercontent.com/12486774/186492290-b3dcb616-bb3f-46f3-901e-157274f67b92.png">|







