### PR TITLE
feat: retry on empty response

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ const { getHistoricalRates } = require('dukascopy-node');
 |`useCache`|`Boolean`|`false`|A flag indicating whether a file-system cache is going to be used to store response artifacts for subsequent lookups. When set to `true`, it significantly speeds up calls when requesting overlapping or similar data|
 |`cacheFolderPath`|`String`|`./.dukascopy-cache`|Folder path where all cache artifacts (binary data) will be stored|
 |`retryCount`|`Number`|`0`|Number of retries for a failed artifact download. If `0` no retries will happen even for failed requests.|
-|`retryOnEmpty`|`Boolean`|`false`|A flag indicating whether requests with successful but empty (0 Bytes) responses should be retried. If `retryCount` is `0` this parameter will be ignored |
+|`retryOnEmpty`|`Boolean`|`false`|A flag indicating whether requests with successful but empty (0 Bytes) responses should be retried. If `retryCount` is `0` this parameter will be ignored|
 |`pauseBetweenRetriesMs`|`Number`|`500`|Pause between retries. If `retryCount` is `0` this parameter will be ignored|
 
 ***
@@ -158,6 +158,7 @@ const { getHistoricalRates } = require('dukascopy-node');
   useCache: true,
   cacheFolderPath: '.dukascopy-cache',
   retryCount: 5,
+  retryOnEmpty: false,
   pauseBetweenRetriesMs: 250
 }
 ```

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ const { getHistoricalRates } = require('dukascopy-node');
 |`cacheFolderPath`|`String`|`./.dukascopy-cache`|Folder path where all cache artifacts (binary data) will be stored|
 |`retryCount`|`Number`|`0`|Number of retries for a failed artifact download. If `0` no retries will happen even for failed requests.|
 |`retryOnEmpty`|`Boolean`|`false`|A flag indicating whether requests with successful but empty (0 Bytes) responses should be retried. If `retryCount` is `0` this parameter will be ignored|
+|`failAfterRetryCount`|`Boolean`|`true`|A flag indicating whether the process should fail after all retries have been exhausted. If `retries` is `0` this parameter will be ignored.|
 |`pauseBetweenRetriesMs`|`Number`|`500`|Pause between retries. If `retryCount` is `0` this parameter will be ignored|
 
 ***

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Options:
   -p, --price-type <value>       Price type: (bid, ask) (default: "bid")
   -utc, --utc-offset <value>     UTC offset in minutes (default: 0)
   -v, --volumes                  Include volumes (default: false)
-  -vu, --volume-units  <value>   Volume units (millions, thousands, units) (default: "millions")
+  -vu, --volume-units <value>    Volume units (millions, thousands, units) (default: "millions")
   -fl, --flats                   Include flats (0 volumes) (default: false)
   -f, --format <value>           Output format (csv, json, array) (default: "json")
   -dir, --directory <value>      Download directory (default: "./download")
@@ -73,6 +73,8 @@ Options:
   -chpath, --cache-path <value>  Folder path for cache data (default: "./.dukascopy-cache")
   -r, --retries <value>          Number of retries for a failed artifact download (default: 0)
   -rp, --retry-pause <value>     Pause between retries in milliseconds (default: 500)
+  -re, --retry-on-empty          A flag indicating whether requests with successful but empty (0 Bytes) responses should be retried. If `retries` is `0`
+                                 this parameter will be ignored (default: false)
   -in, --inline                  Makes files smaller in size by removing new lines in the output (works only with json and array formats) (default: false)
   -h, --help                     display help for command
 ```

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ const { getHistoricalRates } = require('dukascopy-node');
 |`useCache`|`Boolean`|`false`|A flag indicating whether a file-system cache is going to be used to store response artifacts for subsequent lookups. When set to `true`, it significantly speeds up calls when requesting overlapping or similar data|
 |`cacheFolderPath`|`String`|`./.dukascopy-cache`|Folder path where all cache artifacts (binary data) will be stored|
 |`retryCount`|`Number`|`0`|Number of retries for a failed artifact download. If `0` no retries will happen even for failed requests.|
+|`retryOnEmpty`|`Boolean`|`false`|A flag indicating whether requests with successful but empty (0 Bytes) responses should be retried. If `retryCount` is `0` this parameter will be ignored |
 |`pauseBetweenRetriesMs`|`Number`|`500`|Pause between retries. If `retryCount` is `0` this parameter will be ignored|
 
 ***

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Options:
   -chpath, --cache-path <value>  Folder path for cache data (default: "./.dukascopy-cache")
   -r, --retries <value>          Number of retries for a failed artifact download (default: 0)
   -rp, --retry-pause <value>     Pause between retries in milliseconds (default: 500)
-  -re, --retry-on-empty          A flag indicating whether requests with successful but empty (0 Bytes) responses should be retried. If `retries` is `0`
-                                 this parameter will be ignored (default: false)
+  -re, --retry-on-empty          A flag indicating whether requests with successful but empty (0 Bytes) responses should be retried. If `retries` is `0` this parameter will be
+                                 ignored (default: false)
+  -fr, --no-fail-after-retries   A flag indicating whether the process should fail after all retries have been exhausted. If `retries` is `0` this parameter will be ignored
   -in, --inline                  Makes files smaller in size by removing new lines in the output (works only with json and array formats) (default: false)
   -h, --help                     display help for command
 ```
@@ -161,6 +162,7 @@ const { getHistoricalRates } = require('dukascopy-node');
   cacheFolderPath: '.dukascopy-cache',
   retryCount: 5,
   retryOnEmpty: false,
+  failAfterRetryCount: true,
   pauseBetweenRetriesMs: 250
 }
 ```

--- a/src/buffer-fetcher/index.ts
+++ b/src/buffer-fetcher/index.ts
@@ -167,11 +167,11 @@ export class BufferFetcher {
         }
 
         const isStatusOk = response.status === 200;
-        const isEmptyResponse = Number(response?.headers?.get('content-length') || 0) === 0;
+        const isResponseWithData = Number(response?.headers?.get('content-length') || 0) > 0;
         isTrySuccess = isCallSuccess && isStatusOk;
 
         if (this.retryOnEmpty) {
-          isTrySuccess = isTrySuccess && isEmptyResponse;
+          isTrySuccess = isTrySuccess && isResponseWithData;
         }
 
         retries++;

--- a/src/buffer-fetcher/index.ts
+++ b/src/buffer-fetcher/index.ts
@@ -12,7 +12,7 @@ export class BufferFetcher {
   retryCount: number;
   retryOnEmpty: boolean;
   pauseBetweenRetriesMs: number;
-  failAfterRetries: BufferFetcherInput['failAfterRetries'];
+  failAfterRetryCount: BufferFetcherInput['failAfterRetryCount'];
   cacheManager?: CacheManagerBase;
 
   constructor({
@@ -23,7 +23,7 @@ export class BufferFetcher {
     fetcherFn,
     retryCount = 0,
     retryOnEmpty = false,
-    failAfterRetries = true,
+    failAfterRetryCount = true,
     pauseBetweenRetriesMs = 500,
     cacheManager
   }: BufferFetcherInput) {
@@ -35,7 +35,7 @@ export class BufferFetcher {
     this.cacheManager = cacheManager;
     this.retryCount = retryCount;
     this.retryOnEmpty = retryOnEmpty;
-    this.failAfterRetries = failAfterRetries;
+    this.failAfterRetryCount = failAfterRetryCount;
     this.pauseBetweenRetriesMs = pauseBetweenRetriesMs;
   }
 
@@ -182,7 +182,7 @@ export class BufferFetcher {
         if (!isTrySuccess && !isLastRetry) {
           await wait(this.pauseBetweenRetriesMs);
         }
-        if (isLastRetry && !isTrySuccess && this.failAfterRetries) {
+        if (isLastRetry && !isTrySuccess && this.failAfterRetryCount) {
           throw Error(errorMsg || 'Unknown error');
         }
       }

--- a/src/buffer-fetcher/index.ts
+++ b/src/buffer-fetcher/index.ts
@@ -148,7 +148,7 @@ export class BufferFetcher {
       return this.fetcherFn(url);
     }
 
-    let data = new Response();
+    let response = new Response();
 
     const shouldUseRetry = this.retryCount > 0;
 
@@ -160,14 +160,14 @@ export class BufferFetcher {
         const isLastRetry = retries === this.retryCount;
         let isCallSuccess = true;
         try {
-          data = await fetch(url);
+          response = await fetch(url);
         } catch (e) {
           isCallSuccess = false;
           errorMsg = e instanceof Error ? e.message : JSON.stringify(e);
         }
 
-        const isStatusOk = data.status === 200;
-        const isEmptyResponse = Number(data?.headers?.get('content-length') || 0) === 0;
+        const isStatusOk = response.status === 200;
+        const isEmptyResponse = Number(response?.headers?.get('content-length') || 0) === 0;
         isTrySuccess = isCallSuccess && isStatusOk;
 
         if (this.retryOnEmpty) {
@@ -183,9 +183,9 @@ export class BufferFetcher {
         }
       }
     } else {
-      data = await fetch(url);
+      response = await fetch(url);
     }
 
-    return data.status === 200 ? data.buffer() : Buffer.from('', 'utf8');
+    return response.status === 200 ? response.buffer() : Buffer.from('', 'utf8');
   }
 }

--- a/src/buffer-fetcher/index.ts
+++ b/src/buffer-fetcher/index.ts
@@ -167,11 +167,11 @@ export class BufferFetcher {
         }
 
         const isStatusOk = data.status === 200;
-        const isEmptyResponse = Number(data?.headers?.get('content-length') || 0) > 0;
+        const isEmptyResponse = Number(data?.headers?.get('content-length') || 0) === 0;
         isTrySuccess = isCallSuccess && isStatusOk;
 
         if (this.retryOnEmpty) {
-          isTrySuccess = isTrySuccess && !isEmptyResponse;
+          isTrySuccess = isTrySuccess && isEmptyResponse;
         }
 
         retries++;

--- a/src/buffer-fetcher/types.ts
+++ b/src/buffer-fetcher/types.ts
@@ -15,6 +15,6 @@ export interface BufferFetcherInput {
   cacheManager?: CacheManagerBase;
   retryCount?: number;
   retryOnEmpty?: boolean;
-  failAfterRetries?: boolean;
+  failAfterRetryCount?: boolean;
   pauseBetweenRetriesMs?: number;
 }

--- a/src/buffer-fetcher/types.ts
+++ b/src/buffer-fetcher/types.ts
@@ -14,5 +14,6 @@ export interface BufferFetcherInput {
   fetcherFn?: (url: string) => Promise<Buffer>;
   cacheManager?: CacheManagerBase;
   retryCount?: number;
+  retryOnEmpty?: boolean;
   pauseBetweenRetriesMs?: number;
 }

--- a/src/buffer-fetcher/types.ts
+++ b/src/buffer-fetcher/types.ts
@@ -15,5 +15,6 @@ export interface BufferFetcherInput {
   cacheManager?: CacheManagerBase;
   retryCount?: number;
   retryOnEmpty?: boolean;
+  failAfterRetries?: boolean;
   pauseBetweenRetriesMs?: number;
 }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -45,6 +45,7 @@ export async function run(argv: NodeJS.Process['argv']) {
     debug: isDebugActive,
     inline,
     retryCount,
+    failAfterRetryCount,
     retryOnEmpty,
     pauseBetweenRetriesMs
   } = input;
@@ -133,6 +134,7 @@ export async function run(argv: NodeJS.Process['argv']) {
         cacheManager: useCache ? new CacheManager({ cacheFolderPath }) : undefined,
         retryCount,
         retryOnEmpty,
+        failAfterRetryCount,
         pauseBetweenRetriesMs,
         onItemFetch: (url, buffer, isCacheHit): void => {
           debug(`${DEBUG_NAMESPACE}:fetcher`)(

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -45,6 +45,7 @@ export async function run(argv: NodeJS.Process['argv']) {
     debug: isDebugActive,
     inline,
     retryCount,
+    retryOnEmpty,
     pauseBetweenRetriesMs
   } = input;
 
@@ -131,6 +132,7 @@ export async function run(argv: NodeJS.Process['argv']) {
         pauseBetweenBatchesMs,
         cacheManager: useCache ? new CacheManager({ cacheFolderPath }) : undefined,
         retryCount,
+        retryOnEmpty,
         pauseBetweenRetriesMs,
         onItemFetch: (url, buffer, isCacheHit): void => {
           debug(`${DEBUG_NAMESPACE}:fetcher`)(

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -45,7 +45,11 @@ const commanderSchema = program
   .option('-chpath, --cache-path <value>', 'Folder path for cache data', './.dukascopy-cache')
   .option('-r, --retries <value>', 'Number of retries for a failed artifact download', Number, 0)
   .option('-rp, --retry-pause <value>', 'Pause between retries in milliseconds', Number, 500)
-  .option('-re, --retry-on-empty', 'Retry on empty response', false)
+  .option(
+    '-re, --retry-on-empty',
+    'A flag indicating whether requests with successful but empty (0 Bytes) responses should be retried. If `retries` is `0` this parameter will be ignored',
+    false
+  )
   .option(
     '-in, --inline',
     'Makes files smaller in size by removing new lines in the output (works only with json and array formats)',

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -45,6 +45,7 @@ const commanderSchema = program
   .option('-chpath, --cache-path <value>', 'Folder path for cache data', './.dukascopy-cache')
   .option('-r, --retries <value>', 'Number of retries for a failed artifact download', Number, 0)
   .option('-rp, --retry-pause <value>', 'Pause between retries in milliseconds', Number, 500)
+  .option('-re, --retry-on-empty', 'Retry on empty response', false)
   .option(
     '-in, --inline',
     'Makes files smaller in size by removing new lines in the output (works only with json and array formats)',
@@ -79,6 +80,7 @@ export function getConfigFromCliArgs(argv: NodeJS.Process['argv']) {
     useCache: options.cache,
     cacheFolderPath: options.cachePath,
     retryCount: options.retries,
+    retryOnEmpty: options.retryOnEmpty,
     pauseBetweenRetriesMs: options.retryPause,
     debug: options.debug,
     inline: options.inline

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -51,6 +51,10 @@ const commanderSchema = program
     false
   )
   .option(
+    '-nfr, --no-fail-after-retries',
+    'A flag indicating whether the process should fail after all retries have been exhausted. If `retries` is `0` this parameter will be ignored'
+  )
+  .option(
     '-in, --inline',
     'Makes files smaller in size by removing new lines in the output (works only with json and array formats)',
     false
@@ -84,6 +88,7 @@ export function getConfigFromCliArgs(argv: NodeJS.Process['argv']) {
     useCache: options.cache,
     cacheFolderPath: options.cachePath,
     retryCount: options.retries,
+    failAfterRetryCount: options.failAfterRetries,
     retryOnEmpty: options.retryOnEmpty,
     pauseBetweenRetriesMs: options.retryPause,
     debug: options.debug,

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -51,7 +51,7 @@ const commanderSchema = program
     false
   )
   .option(
-    '-nfr, --no-fail-after-retries',
+    '-fr, --no-fail-after-retries',
     'A flag indicating whether the process should fail after all retries have been exhausted. If `retries` is `0` this parameter will be ignored'
   )
   .option(

--- a/src/config-validator/schema.ts
+++ b/src/config-validator/schema.ts
@@ -80,6 +80,11 @@ export const schema: InputSchema<Config> = {
     optional: true,
     default: defaultConfig.retryCount
   } as RuleNumber,
+  retryOnEmpty: {
+    type: 'boolean',
+    optional: true,
+    default: defaultConfig.useCache
+  } as RuleBoolean,
   pauseBetweenRetriesMs: {
     type: 'number',
     integer: true,

--- a/src/config-validator/schema.ts
+++ b/src/config-validator/schema.ts
@@ -85,6 +85,11 @@ export const schema: InputSchema<Config> = {
     optional: true,
     default: defaultConfig.useCache
   } as RuleBoolean,
+  failAfterRetryCount: {
+    type: 'boolean',
+    optional: true,
+    default: defaultConfig.failAfterRetryCount
+  } as RuleBoolean,
   pauseBetweenRetriesMs: {
     type: 'number',
     integer: true,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -29,6 +29,7 @@ export interface ConfigBase {
   useCache?: boolean;
   cacheFolderPath?: string;
   retryCount?: number;
+  retryOnEmpty?: boolean;
   pauseBetweenRetriesMs?: number;
 }
 
@@ -47,6 +48,7 @@ export const defaultConfig: DefaultConfig = {
   useCache: false,
   cacheFolderPath: '',
   retryCount: 0,
+  retryOnEmpty: false,
   pauseBetweenRetriesMs: 500
 };
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -30,6 +30,7 @@ export interface ConfigBase {
   cacheFolderPath?: string;
   retryCount?: number;
   retryOnEmpty?: boolean;
+  failAfterRetryCount?: boolean;
   pauseBetweenRetriesMs?: number;
 }
 
@@ -49,6 +50,7 @@ export const defaultConfig: DefaultConfig = {
   cacheFolderPath: '',
   retryCount: 0,
   retryOnEmpty: false,
+  failAfterRetryCount: true,
   pauseBetweenRetriesMs: 500
 };
 

--- a/src/getHistoricalRates.ts
+++ b/src/getHistoricalRates.ts
@@ -65,7 +65,8 @@ export async function getHistoricalRates(config: Config): Promise<Output> {
     useCache,
     cacheFolderPath,
     retryCount,
-    pauseBetweenRetriesMs
+    pauseBetweenRetriesMs,
+    retryOnEmpty
   } = input;
 
   const [startDate, endDate] = normaliseDates({
@@ -103,7 +104,8 @@ export async function getHistoricalRates(config: Config): Promise<Output> {
     cacheManager: useCache ? new CacheManager({ cacheFolderPath }) : undefined,
     retryCount,
     pauseBetweenRetriesMs,
-    onItemFetch
+    onItemFetch,
+    retryOnEmpty
   });
 
   const bufferredData = await bufferFetcher.fetch(urls);


### PR DESCRIPTION
If response for the binary artifact request is empty (0 Bytes), applying the existing retry mechanism.

As per: https://github.com/Leo4815162342/dukascopy-node/issues/130