### PR TITLE
feat: more sensible error codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
 	},
 	"scripts": {
 		"build": "rm -rf dist && tsup-node src/index.ts src/cli/index.ts --format esm,cjs --dts --legacy-output",
-		"prepare": "npm run build",
 		"test": "vitest run",
 		"coverage": "vitest run --coverage",
 		"format": "prettier --config .prettierrc 'src/**/*.ts' --write",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	},
 	"scripts": {
 		"build": "rm -rf dist && tsup-node src/index.ts src/cli/index.ts --format esm,cjs --dts --legacy-output",
+		"prepare": "npm run build",
 		"test": "vitest run",
 		"coverage": "vitest run --coverage",
 		"format": "prettier --config .prettierrc 'src/**/*.ts' --write",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -225,11 +225,11 @@ export async function run(argv: NodeJS.Process['argv']) {
         'Search config invalid:',
         validationErrors.map(err => err?.message || '')
       );
-      process.exit(0);
+      process.exit(65);
     }
   } catch (err: unknown) {
     const errorMsg = err instanceof Error ? err.message : JSON.stringify(err);
     printErrors('\nSomething went wrong:', errorMsg);
-    process.exit(0);
+    process.exit(66);
   }
 }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -225,11 +225,11 @@ export async function run(argv: NodeJS.Process['argv']) {
         'Search config invalid:',
         validationErrors.map(err => err?.message || '')
       );
-      process.exit(65);
+      process.exit(1);
     }
   } catch (err: unknown) {
     const errorMsg = err instanceof Error ? err.message : JSON.stringify(err);
     printErrors('\nSomething went wrong:', errorMsg);
-    process.exit(66);
+    process.exit(1);
   }
 }

--- a/src/utils/MemoryUsageReporter.ts
+++ b/src/utils/MemoryUsageReporter.ts
@@ -48,6 +48,6 @@ export class MemoryUsageReporter {
     console.log('Stopping memory usage tracker', reason);
     clearInterval(this.interval);
     this.interval = null;
-    process.exit(0);
+    process.exit(67);
   }
 }

--- a/src/utils/MemoryUsageReporter.ts
+++ b/src/utils/MemoryUsageReporter.ts
@@ -48,6 +48,6 @@ export class MemoryUsageReporter {
     console.log('Stopping memory usage tracker', reason);
     clearInterval(this.interval);
     this.interval = null;
-    process.exit(67);
+    process.exit(1);
   }
 }


### PR DESCRIPTION
If you run this on a linux terminal:
```
npx dukascopy-node -i 'usdsfk' -from '2018-04-15' -to '2018-05-16' -f csv -t tick -r 0 -fr false -re true
echo $?
```
You see an error being printed to console (as "usdsfk" is not known). But the process returns 0. So there is no way to programatically tell that you had an error. This also happens if a network error causes you to not download all ticks (and hence your code may pass on without detecting this).

To fix this I change the process.exit() codes to something that is not 0. I picked three random numbers but not sure if there are more appropriate ones.

