### PR TITLE
Fix: Replace colons in filename timestamps for Windows compatibility

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -104,7 +104,7 @@ export async function run(argv: NodeJS.Process['argv']) {
             cutoff = 16;
           }
 
-          return date.toISOString().slice(0, cutoff);
+          return date.toISOString().slice(0, cutoff).replace(/:/g, '-');
         })
         .join('-');
 


### PR DESCRIPTION
## Description
Fixes filename generation when date ranges include times with hours/minutes, causing illegal colons in filenames on Windows.

## Problem

When downloading data with timestamps that fall outside available data ranges, the normalized dates include full timestamps (hours:minutes). The current code truncates ISO strings but doesn't remove colons, causing an issue when working in Windows/Cygwin resulting in file creation getting truncated at the first colon, resulting in files without extensions (e.g., `eurusd-tick-2020-01-01T14` instead of `eurusd-tick-2020-01-01T14:30-2020-01-02T15:45.csv`), which then leads to downloaded data being stored nowhere. The download process completes with a success message reporting back the intended filename (including colons), but the actually created file with the truncated name contains 0 bytes.

Presumably (although not tested here), under macOS it would also fail because colons are converted to slashes by the filesystem, causing path issues. While under Linux, colons are valid in filenames, which is why Linux users might never experience this.

## Solution
Replace all colons with hyphens in the date range string after ISO string truncation (line 120).

**Changed line:**
```typescript
return date.toISOString().slice(0, cutoff).replace(/:/g, '-');
```

## Testing
- Tested on Windows 10 (64 bit) via Cygwin
- Verified with edge case timestamps containing hours and minutes
- Confirmed files are created with correct names and extensions, and contain the downloaded data

## Note
During testing, encountered a dependency conflict between `prettier@2.6.2` and `eslint-plugin-prettier@5.5.4` (requires prettier >= 3.0.0). Used `npm install --legacy-peer-deps` to proceed with testing. This may warrant a separate fix.

## AI Support Note
This contribution was created with the help of Claude Sonnet 4.5.
