### PR TITLE
Add FXMacroData client

### DIFF
--- a/src/fxmacrodata.test.ts
+++ b/src/fxmacrodata.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { FxMacroDataClient } from './fxmacrodata';
+
+function response(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'content-type': 'application/json' }
+  });
+}
+
+describe('FxMacroDataClient', () => {
+  it('adds API key as a query parameter', async () => {
+    const urls: string[] = [];
+    const client = new FxMacroDataClient({
+      apiKey: 'test-key',
+      baseUrl: 'https://example.test/api/v1',
+      fetchImpl: async input => {
+        urls.push(String(input));
+        return response({ ok: true });
+      }
+    });
+
+    await client.forex('eur', 'usd', { start_date: '2026-07-01' });
+
+    const url = new URL(urls[0]);
+    expect(url.pathname).toBe('/api/v1/forex/eur/usd');
+    expect(url.searchParams.get('start_date')).toBe('2026-07-01');
+    expect(url.searchParams.get('api_key')).toBe('test-key');
+  });
+
+  it('covers the macro, FX, calendar, COT, commodity, and curve endpoints', async () => {
+    const paths: string[] = [];
+    const client = new FxMacroDataClient({
+      baseUrl: 'https://example.test/v1',
+      fetchImpl: async input => {
+        paths.push(new URL(String(input)).pathname);
+        return response({ ok: true });
+      }
+    });
+
+    await client.dataCatalogue('usd');
+    await client.announcements('usd', 'cpi');
+    await client.latestAnnouncements('usd');
+    await client.announcementChanges();
+    await client.calendar('usd');
+    await client.predictions('usd', 'cpi');
+    await client.forex('eur', 'usd');
+    await client.cot('jpy');
+    await client.commodity('brent');
+    await client.commoditiesLatest();
+    await client.curves('usd');
+    await client.curveProxies('usd');
+    await client.forwardCurves('usd');
+    await client.rateDifferentials('eur', 'usd');
+    await client.forwardDifferentials('eur', 'usd');
+    await client.marketSessions();
+    await client.riskSentiment();
+    await client.news('usd');
+    await client.pressReleases('usd');
+
+    expect(paths).toEqual([
+      '/v1/data_catalogue/usd',
+      '/v1/announcements/usd/cpi',
+      '/v1/announcements/usd/latest',
+      '/v1/announcements/changes',
+      '/v1/calendar/usd',
+      '/v1/predictions/usd/cpi',
+      '/v1/forex/eur/usd',
+      '/v1/cot/jpy',
+      '/v1/commodities/brent',
+      '/v1/commodities/latest',
+      '/v1/curves/usd',
+      '/v1/curve_proxies/usd',
+      '/v1/forward_curves/usd',
+      '/v1/rate_differentials/eur/usd',
+      '/v1/forward_differentials/eur/usd',
+      '/v1/market_sessions',
+      '/v1/risk_sentiment',
+      '/v1/news/usd',
+      '/v1/press-releases/usd'
+    ]);
+  });
+
+  it('posts GraphQL requests', async () => {
+    let method = '';
+    let body = '';
+    const client = new FxMacroDataClient({
+      baseUrl: 'https://example.test/v1',
+      fetchImpl: async (_input, init) => {
+        method = init?.method || '';
+        body = String(init?.body);
+        return response({ data: { ping: true } });
+      }
+    });
+
+    await client.graphql({ query: '{ ping }' });
+
+    expect(method).toBe('POST');
+    expect(JSON.parse(body)).toEqual({ query: '{ ping }' });
+  });
+});

--- a/src/fxmacrodata.ts
+++ b/src/fxmacrodata.ts
@@ -1,0 +1,158 @@
+export type FxMacroDataQueryValue = string | number | boolean | Date | null | undefined;
+export type FxMacroDataQuery = Record<string, FxMacroDataQueryValue | FxMacroDataQueryValue[]>;
+
+export interface FxMacroDataClientOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface GraphQLRequest {
+  query: string;
+  variables?: Record<string, unknown>;
+  operationName?: string;
+}
+
+const DEFAULT_BASE_URL = 'https://fxmacrodata.com/api/v1';
+
+function getApiKey(apiKey?: string): string | undefined {
+  return apiKey || process.env.FXMACRODATA_API_KEY || process.env.FXMD_API_KEY;
+}
+
+function appendQuery(url: URL, query?: FxMacroDataQuery): void {
+  for (const [key, rawValue] of Object.entries(query || {})) {
+    const values = Array.isArray(rawValue) ? rawValue : [rawValue];
+    for (const value of values) {
+      if (value === undefined || value === null) {
+        continue;
+      }
+      url.searchParams.append(key, value instanceof Date ? value.toISOString() : String(value));
+    }
+  }
+}
+
+export class FxMacroDataClient {
+  private readonly apiKey?: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: FxMacroDataClientOptions = {}) {
+    this.apiKey = getApiKey(options.apiKey);
+    this.baseUrl = (options.baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '');
+    this.fetchImpl = options.fetchImpl || fetch;
+  }
+
+  async request<T = unknown>(
+    path: string,
+    query?: FxMacroDataQuery,
+    init: RequestInit = {}
+  ): Promise<T> {
+    const url = new URL(`${this.baseUrl}/${path.replace(/^\/+/, '')}`);
+    appendQuery(url, query);
+    if (this.apiKey && !url.searchParams.has('api_key')) {
+      url.searchParams.set('api_key', this.apiKey);
+    }
+
+    const response = await this.fetchImpl(url, {
+      ...init,
+      headers: {
+        accept: 'application/json',
+        ...(init.headers || {})
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`FXMacroData request failed: ${response.status} ${await response.text()}`);
+    }
+
+    return (await response.json()) as T;
+  }
+
+  dataCatalogue(currency: string): Promise<unknown> {
+    return this.request(`data_catalogue/${currency}`);
+  }
+
+  announcements(currency: string, indicator: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`announcements/${currency}/${indicator}`, query);
+  }
+
+  latestAnnouncements(currency: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`announcements/${currency}/latest`, query);
+  }
+
+  announcementChanges(query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request('announcements/changes', query);
+  }
+
+  calendar(currency: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`calendar/${currency}`, query);
+  }
+
+  predictions(currency: string, indicator: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`predictions/${currency}/${indicator}`, query);
+  }
+
+  forex(base: string, quote: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`forex/${base}/${quote}`, query);
+  }
+
+  cot(currency: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`cot/${currency}`, query);
+  }
+
+  commodity(indicator: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`commodities/${indicator}`, query);
+  }
+
+  commoditiesLatest(query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request('commodities/latest', query);
+  }
+
+  curves(currency: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`curves/${currency}`, query);
+  }
+
+  curveProxies(currency: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`curve_proxies/${currency}`, query);
+  }
+
+  forwardCurves(currency: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`forward_curves/${currency}`, query);
+  }
+
+  rateDifferentials(base: string, quote: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`rate_differentials/${base}/${quote}`, query);
+  }
+
+  forwardDifferentials(base: string, quote: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`forward_differentials/${base}/${quote}`, query);
+  }
+
+  marketSessions(query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request('market_sessions', query);
+  }
+
+  riskSentiment(query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request('risk_sentiment', query);
+  }
+
+  news(currency: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`news/${currency}`, query);
+  }
+
+  pressReleases(currency: string, query?: FxMacroDataQuery): Promise<unknown> {
+    return this.request(`press-releases/${currency}`, query);
+  }
+
+  graphql<T = unknown>(request: GraphQLRequest): Promise<T> {
+    return this.request<T>('graphql', undefined, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(request)
+    });
+  }
+}
+
+export function createFxMacroDataClient(options?: FxMacroDataClientOptions): FxMacroDataClient {
+  return new FxMacroDataClient(options);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,3 +46,11 @@ export {
 } from './getRealTimeRates';
 
 export { instrumentMetaData } from './config/instruments-metadata';
+export {
+  createFxMacroDataClient,
+  FxMacroDataClient,
+  FxMacroDataClientOptions,
+  FxMacroDataQuery,
+  FxMacroDataQueryValue,
+  GraphQLRequest
+} from './fxmacrodata';


### PR DESCRIPTION
## Summary
- add a fetch-based FXMacroData client alongside the Dukascopy exports
- cover catalogue, announcements, predictions, forex, COT, commodities, curves, differentials, sessions, risk sentiment, news, press releases, generic requests, and GraphQL
- add Vitest coverage for auth/query construction and endpoint paths

## Validation
- `pnpm install --frozen-lockfile` populated dependencies but exits with pnpm's existing ignored-builds policy prompt for esbuild/msw
- `node_modules/.bin/vitest.cmd run src/fxmacrodata.test.ts`
- `node_modules/.bin/tsc.cmd --noEmit --skipLibCheck`